### PR TITLE
Fix incorrect `sltu` emulation

### DIFF
--- a/emulator.cpp
+++ b/emulator.cpp
@@ -828,7 +828,7 @@ void execute(uint8_t* mem, instr* imem, label_loc* labels, int label_count, bool
 			case ADD: rf[i.a1.reg] = rf[i.a2.reg] + rf[i.a3.reg]; break;
 			case SUB: rf[i.a1.reg] = rf[i.a2.reg] - rf[i.a3.reg]; break;
 			case SLT: rf[i.a1.reg] = (*(int32_t*)&rf[i.a2.reg]) < (*(int32_t*)&rf[i.a3.reg]) ? 1 : 0; break;
-			case SLTU: rf[i.a1.reg] = rf[i.a2.reg] + rf[i.a3.reg]; break;
+			case SLTU: rf[i.a1.reg] = rf[i.a2.reg] < rf[i.a3.reg] ? 1 : 0; break;
 			case AND: rf[i.a1.reg] = rf[i.a2.reg] & rf[i.a3.reg]; break;
 			case OR: rf[i.a1.reg] = rf[i.a2.reg] | rf[i.a3.reg]; break;
 			case XOR: rf[i.a1.reg] = rf[i.a2.reg] ^ rf[i.a3.reg]; break;


### PR DESCRIPTION
in line 831 of `emulator.cpp`, `sltu` instruction is defined as:

```cpp
case SLTU: rf[i.a1.reg] = rf[i.a2.reg] + rf[i.a3.reg]; break;
```

which is same as `add` instruction.

however, according to the [reference card](https://www.cs.sfu.ca/~ashriram/Courses/CS295/assets/notebooks/RISCV/RISCV_CARD.pdf) of risc-v, `sltu` is defined as `rd = (rs1 < rs2) ? 1 : 0` which makes current implementation incorrect.

i changed it to handle the instruction correctly.

```cpp
case SLTU: rf[i.a1.reg] = rf[i.a2.reg] < rf[i.a3.reg] ? 1 : 0; break;
```

---

we can demonstrate the issue and the fix by using the simple assembly:

```s
.text
start:
    li t0 1
    li t1 2
    sltu t2 t0 t1
    hcf
```

### before the fix

```bash
Next: sltu t2, t0, t1
[inst:      5 pc:     16, src line    5]
>>
>> rf[x07] 0 -> 3
```

here we can see the `t2` register is incorrectly set to `3`.

### after the fix

```bash
Next: sltu t2, t0, t1
[inst:      5 pc:     16, src line    5]
>>
>> rf[x07] 0 -> 1
```

in this case, the `t2` register is set to `1` correctly.