### PR TITLE
Allow both instruction and comment to be in the same line

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ The following are the supported commands:
 ## Caveats
 
 * Pseudo-instructions are not elegantly compiled, yet
-* Only one action per line supported! For example, comments and labels shoud go on their own line
+* Only one instruction per line supported!

--- a/emulator.cpp
+++ b/emulator.cpp
@@ -659,11 +659,12 @@ void parse(FILE* fin, uint8_t* mem, instr* imem, int& memoff, label_loc* labels,
 		if ( !fgets(rbuf, 1024, fin) ) break;
 		for (char* p = rbuf; *p; ++p) *p = tolower(*p);
 		line++;
+		
+		char *comment_ptr = strchr(rbuf, '#');
+		if ( comment_ptr ) *comment_ptr = '\0';
 
 		char* ftok = strtok(rbuf, " \t\r\n");
 		if ( !ftok ) continue;
-
-		if ( ftok[0] == '#' ) continue;
 
 		if ( ftok[strlen(ftok)-1] == ':' ) {
 			ftok[strlen(ftok)-1] = 0;


### PR DESCRIPTION
as mentioned in the caveat, current implementation does not allow the instruction and comment to be in a single line.

asking it to assemble the following line will result an error:

```s
	li t0 0xdeadbeef # hi
```

```bash
$ ./obj/emulator example_questions/reduction.s
Parsing input file
Line   42: Syntax error! Invalid format
```

this PR improves the parsing logic by replacing the first occurance of `#` with `\0`, effectively marking it as end of string.

the previous example assembles successfully after the modification.

```bash
$ ./obj/emulator example_questions/reduction.s
Parsing input file

Next: lui x02, 0x00000010
[inst:      1 pc:      0, src line    4]
>>
```