### PR TITLE
[FIX]: fix make error while build in windows env

### DIFF
--- a/linenoise.hpp
+++ b/linenoise.hpp
@@ -762,7 +762,7 @@ inline void InterpretEscSeq(void)
                             case 6:     // ESC[6n Report cursor position
                                     {
                                     WCHAR buf[32];
-                                    swprintf(buf, 32, L"\33[%d;%dR", Info.dwCursorPosition.Y + 1,
+                                    swprintf(buf, L"\33[%d;%dR", Info.dwCursorPosition.Y + 1,
                                         Info.dwCursorPosition.X + 1);
                                     SendSequence(buf);
                                     }


### PR DESCRIPTION
## problem
while build in windows env g++ throw the error in linenoise.cpp 765 line (swprintf)
```
linenoise.hpp: In function 'void linenoise::ansi::InterpretEscSeq()':
linenoise.hpp:766:68: error: invalid conversion from 'int' to 'const wchar_t*' [-fpermissive]
Info.dwCursorPosition.X + 1);
```
windows c++ compiler (MinGW/g++) doesn't take buffer size

## change
i remove buffer size from 765 line
<img width="1211" height="172" alt="image" src="https://github.com/user-attachments/assets/d541cf81-7b74-4259-80b8-cb09adcc8719" />
