### PR TITLE
Cache to memory flush에서 dirty-bit write-back 기능 추가

### DIFF
--- a/cachesim.cpp
+++ b/cachesim.cpp
@@ -5,6 +5,10 @@ uint32_t g_cache[CACHE_SETS][CACHE_WAYS][CACHE_LINE_WORD] = {0};
 uint32_t g_tags[CACHE_SETS][CACHE_WAYS] = {0};
 uint8_t g_flags[CACHE_SETS][CACHE_WAYS] = {0};
 
+#define FLAG_VALID (1u<<0)
+#define FLAG_DIRTY (1u<<1)
+
+
 uint32_t cache_calc_idx(uint32_t addr) {
 		return ((addr>>(CACHE_LINE_WORD_SZ+2)) & ((1<<CACHE_SETS_SZ)-1));
 }
@@ -21,15 +25,12 @@ uint32_t cache_reassemble_addr(uint32_t idx, uint32_t tag) {
 		return (idx<<(CACHE_LINE_WORD_SZ+2)) | (tag<<(CACHE_SETS_SZ+CACHE_LINE_WORD_SZ+2));
 }
 
-bool is_flag_valid(uint8_t flags) {
-	return ((flags&1) == 0)?false:true;
-}
-uint8_t set_flag_valid(uint8_t flags) {
-	return (flags | 1);
-}
-uint8_t set_flag_invalid(uint8_t flags) {
-	return flags - (flags & 1);
-}
+bool is_flag_valid(uint8_t f)     { return (f & FLAG_VALID) != 0; }
+bool is_flag_dirty(uint8_t f)     { return (f & FLAG_DIRTY) != 0; }
+uint8_t set_flag_valid(uint8_t f) { return f | FLAG_VALID; }
+uint8_t set_flag_dirty(uint8_t f) { return f | FLAG_DIRTY; }
+uint8_t clr_flag_dirty(uint8_t f) { return (uint8_t)(f & ~FLAG_DIRTY); }
+uint8_t set_flag_invalid(uint8_t f){ return (uint8_t)(f & ~(FLAG_VALID | FLAG_DIRTY)); }
 
 int cache_peek(uint32_t addr, int bytes) {
 	uint32_t idx = cache_calc_idx(addr);
@@ -54,7 +55,6 @@ void cache_write(uint32_t addr, uint32_t data, int bytes) {
 	if ( way < 0 ) {
 		return;
 	}
-	
 
 	switch ( bytes ) {
 		case 1: {
@@ -72,6 +72,7 @@ void cache_write(uint32_t addr, uint32_t data, int bytes) {
 			break;
 		}
 	}
+	g_flags[idx][way] = set_flag_dirty(g_flags[idx][way]);
 }
 uint32_t cache_read(uint32_t addr, int bytes) {
 	uint32_t idx = cache_calc_idx(addr);
@@ -82,7 +83,7 @@ uint32_t cache_read(uint32_t addr, int bytes) {
 	if ( way < 0 ) {
 		return 0xffffffff;
 	}
-	
+
 	uint32_t ret = 0xffffffff;
 	switch ( bytes ) {
 		case 1: {
@@ -121,25 +122,27 @@ void cache_update(uint32_t addr, uint32_t data) {
 	g_cache[idx][way][wid] = data;
 	g_tags[idx][way] = tag;
 	g_flags[idx][way] = set_flag_valid(g_flags[idx][way]);
+	g_flags[idx][way] = clr_flag_dirty(set_flag_valid(g_flags[idx][way]));
 }
 
-void cache_flush(uint32_t addr, uint8_t* mem) {
+int cache_flush(uint32_t addr, uint8_t* mem) {
 	uint32_t idx = cache_calc_idx(addr);
-	//uint32_t wid = cache_calc_word_idx(addr);
-
-	//choose way
-	//int way = rand()%CACHE_WAYS;
 	int way = 0;
 
-	if (!is_flag_valid(g_flags[idx][way])) return;
-	uint32_t tag = g_tags[idx][way];
+	if (!is_flag_valid(g_flags[idx][way])) return 0;
 
-	//write to mem
-	//set flag to empty
-	for ( int i = 0; i < CACHE_LINE_WORD; i++ ) {
-		uint32_t data = g_cache[idx][way][i];
-		uint32_t maddr = cache_reassemble_addr(idx, tag) + (i*4);
-		*(uint32_t*)(mem+maddr) = data;
-		g_flags[idx][way] = set_flag_invalid(g_flags[idx][way]);
+	int flushed = 0;
+	if (is_flag_dirty(g_flags[idx][way])) {
+		uint32_t tag = g_tags[idx][way];
+		for (int i = 0; i < CACHE_LINE_WORD; i++) {
+			uint32_t data  = g_cache[idx][way][i];
+			uint32_t maddr = cache_reassemble_addr(idx, tag) + (i * 4);
+			*(uint32_t*)(mem + maddr) = data;
+		}
+		g_flags[idx][way] = clr_flag_dirty(g_flags[idx][way]);
+		flushed = CACHE_LINE_WORD;
 	}
+
+	g_flags[idx][way] = set_flag_invalid(g_flags[idx][way]);
+	return flushed;
 }

--- a/cachesim.h
+++ b/cachesim.h
@@ -23,6 +23,6 @@ int cache_peek(uint32_t addr, int bytes);
 void cache_write(uint32_t addr, uint32_t data, int bytes);
 uint32_t cache_read(uint32_t addr, int bytes) ;
 void cache_update(uint32_t addr, uint32_t data);
-void cache_flush(uint32_t addr, uint8_t* mem);
+int cache_flush(uint32_t addr, uint8_t* mem);
 
 #endif

--- a/emulator.cpp
+++ b/emulator.cpp
@@ -234,12 +234,12 @@ void mem_write(uint8_t* mem, uint32_t addr, uint32_t data, instr_type op) {
 		mem_write_reqs ++;
 		int way = cache_peek(addr,bytes);
 		if ( way < 0 ) {
-			cache_flush(addr, mem);
+			int flushed = cache_flush(addr, mem);
 			uint32_t waddr = addr-(addr&((1<<(2+CACHE_LINE_WORD_SZ))-1));
 			for ( int i = 0; i < CACHE_LINE_WORD; i++ ) {
 				cache_update(waddr+(i*4), *(uint32_t*)&(mem[waddr+(i*4)]));
 			}
-			mem_flush_words += CACHE_LINE_WORD;
+			mem_flush_words += flushed;
 		} else {
 			cache_write_hits ++;
 		}
@@ -265,8 +265,8 @@ uint32_t mem_read(uint8_t* mem, uint32_t addr, instr_type op) {
 		mem_read_reqs ++;
 		int way = cache_peek(addr,bytes);
 		if ( way < 0 ) {
-			cache_flush(addr, mem);
-			mem_flush_words += CACHE_LINE_WORD;
+			int flushed = cache_flush(addr, mem);
+			mem_flush_words += flushed;
 			uint32_t waddr = addr-(addr&((1<<(2+CACHE_LINE_WORD_SZ))-1));
 			for ( int i = 0; i < CACHE_LINE_WORD; i++ ) {
 				cache_update(waddr+(i*4), *(uint32_t*)&(mem[waddr+(i*4)]));


### PR DESCRIPTION
- flags에 FLAG_DIRTY 추가 및 헬퍼 교체
- cache_write: write hit 시 dirty=1
- cache_update: 라인 fill 시 dirty=0로 시작
- cache_flush: dirty일 때만 라인 write-back, 이후 invalidate
- cache_flush 반환형 int로 변경(실제 메모리에 쓴 word 수 리턴)
- cachesim.h: 시그니처 업데이트

## graph.s

- Memory Write-back(Flush) 9459 -> 4768
- 49.6% 성능 개선

### Before

<img width="1443" height="262" alt="image" src="https://github.com/user-attachments/assets/5e06b125-4e8d-46aa-8527-778648892136" />

### After

<img width="1450" height="256" alt="image" src="https://github.com/user-attachments/assets/0cb4bb73-5005-46b9-acd7-d87af088285e" />

## sudoku.s

- Memory Write-back(Flush) 26 -> 0
- Zero Overhead 달성

### Before

<img width="1451" height="260" alt="image" src="https://github.com/user-attachments/assets/6d41596a-ca86-49a2-b082-03a6a9ba6dac" />

### After

<img width="1436" height="256" alt="image" src="https://github.com/user-attachments/assets/cdbe587e-b2a8-408a-8f15-fa01f29ec1cb" />


## sort.s

- Memory Write-back(Flush) 9339 -> 5786
- 38.0% 성능 개선

### Before

<img width="1439" height="260" alt="image" src="https://github.com/user-attachments/assets/07822c55-3d28-4cc8-a607-c943ecdcdb2b" />


### After

<img width="1444" height="263" alt="image" src="https://github.com/user-attachments/assets/de07a8fd-e6a0-4e6b-9d4d-5c2a44983d08" />
